### PR TITLE
use a fixed version of IPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install -i https://test.pypi.org/simple/ eda_analysis
 - pandas = ^1.0.1
 - numpy = ^1.18.1
 - altair = ^3.2.0
-- IPython = ^7.13.0
+- IPython = 7.13.0
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python = "^3.7"
 pandas = "^1.0.1"
 numpy = "^1.18.1"
 altair = "^3.2.0"
-IPython = "^7.13.0"
+IPython = "7.13.0"
 
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.8.1"


### PR DESCRIPTION
It should be able to fix the bug of installing from test PyPI.
close #80 